### PR TITLE
fix-linux-memory-usage-stat

### DIFF
--- a/src/core/stats_linux.go
+++ b/src/core/stats_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 /*
@@ -68,7 +69,7 @@ func (ds *dockerService) getContainerStats(containerID string) (*runtimeapi.Cont
 		Memory: &runtimeapi.MemoryUsage{
 			Timestamp: timestamp,
 			WorkingSetBytes: &runtimeapi.UInt64Value{
-				Value: dockerStats.MemoryStats.PrivateWorkingSet,
+				Value: dockerStats.MemoryStats.Usage,
 			},
 		},
 		WritableLayer: &runtimeapi.FilesystemUsage{


### PR DESCRIPTION
`PrivateWorkingSet` is a Windows metric and 0 on Linux

See https://github.com/Mirantis/cri-dockerd/pull/38#issuecomment-1128105658